### PR TITLE
Add percentage of total income to chart tooltip

### DIFF
--- a/components/charts/index.js
+++ b/components/charts/index.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Pie } from "react-chartjs-2";
 
-ChartJS.register(ArcElement, Tooltip, Legend);
 
 export default function PieChart({ amount, finalIncome }) {
   const preData = [
@@ -38,7 +36,6 @@ export default function PieChart({ amount, finalIncome }) {
       .map((l) => l.label),
     datasets: [
       {
-        label: "€",
         data: preData.map((l) => l.value),
         backgroundColor: [
           "rgba(255, 99, 132, 0.2)",
@@ -61,5 +58,34 @@ export default function PieChart({ amount, finalIncome }) {
     ],
   };
 
-  return <Pie data={data} />;
+  const options = {
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: function (context) {
+            let label = ` ${context.label}`;
+            if (label) {
+              label += ": ";
+            }
+            if (context.parsed !== null) {
+              label += new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "EUR",
+              }).format(context.parsed);
+            }
+            return label;
+          },
+          footer: function (context) {
+            let str = `${(
+              (context[0].parsed / amount.grossIncome.year) *
+              100
+            ).toFixed(1)} % των εσόδων`;
+            return str;
+          },
+        },
+      },
+    },
+  };
+
+  return <Pie data={data} options={options} />;
 }

--- a/components/charts/index.js
+++ b/components/charts/index.js
@@ -1,6 +1,8 @@
 import React from "react";
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Pie } from "react-chartjs-2";
 
+ChartJS.register(ArcElement, Tooltip, Legend);
 
 export default function PieChart({ amount, finalIncome }) {
   const preData = [


### PR DESCRIPTION
This PR adds a % of total income to the Pie chart's tooltips:
![image](https://user-images.githubusercontent.com/1778990/175807360-9305b0ff-4e32-45bc-b7d6-335915684417.png)
