### PR TITLE
Fixed Insurance percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🧮 Taxemu
 
-_This is the **alpha version** of Taxemu. A tool to calculate your tax obligations. Made for one-person business and regular employees._
+_This is the **alpha version** of Taxemu. A tool to calculate your tax obligations. Made for one-person business and permanent employees._
 
 The live project can be found [here](https://www.taxemu.gr/).
 

--- a/hooks/useCalculateEmployee.js
+++ b/hooks/useCalculateEmployee.js
@@ -111,7 +111,7 @@ export const useCalculateEmployee = () => {
       activeInput === "gross" ? grossIncomeMonthly : outsideGrossMonth;
 
     const insuranceMonthly = Math.round(
-      currentGrossMonth * taxationYearScales[taxationYear].insurancePercentage
+      Math.min(currentGrossMonth,taxationYearScales[taxationYear].maxTaxableSalary) * taxationYearScales[taxationYear].insurancePercentage
     );
 
     const sumToBeTaxed =

--- a/store.js
+++ b/store.js
@@ -48,11 +48,17 @@ const initialState = {
     },
     insuranceCarrier: "efka", // efka | tsmede
     taxationYearScales: {
+      2023: {
+        insurancePercentage: 0.1387,
+        maxTaxableSalary: 7126.94,
+      },
       2022: {
         insurancePercentage: 0.1387,
+        maxTaxableSalary: 6500,
       },
       2021: {
         insurancePercentage: 0.1412,
+        maxTaxableSalary: 6500,
       },
     },
     servicesFMY: 0,


### PR DESCRIPTION
Insurance percentage maxes out at a certain gross income salary threshold. Anything above this threshold does not increase the insurance contribution. For example, for 2023 the maximum monthly gross taxable income is 7.126,94 €. Therefore anything above that does not increase insurance contributions.

See here for an example article that provides more info: https://www.forin.gr/articles/article/68549/efka-egk-10-2023